### PR TITLE
Bug fix on response not 200 exception raise.

### DIFF
--- a/src/address_lookup/clients/here_client.py
+++ b/src/address_lookup/clients/here_client.py
@@ -103,7 +103,7 @@ class AddressLookupHereClient(AddressLookupClient):
             response_json = response.json()
             if "error" in response_json:
                 raise AddressLookupException(
-                    f'Error "{response["error"]}" ({response.status_code}) from HERE API: {response["error_description"]}'
+                    f'Error "{response_json["error"]}" ({response.status_code}) from HERE API: {response_json["error_description"]}'
                 )
             else:
                 raise AddressLookupException(


### PR DESCRIPTION
Raising AddressLookupException when response.status_code is not 200, a TypeError is raised, because it's trying to get values of keys - 'error' and 'error_description' from response object instead of response_json:

```
    f'Error "{response["error"]}" ({response.status_code}) from HERE API: {response["error_description"]}'
              ~~~~~~~~^^^^^^^^^
TypeError: 'Response' object is not subscriptable
```
After fixing and testing the mistake, it works as intended:

` Error "Too Many Requests" (429) from HERE API: Rate limit for this service has been reached`
